### PR TITLE
feat: Updating how runners get smile-ci-service github token

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,7 @@ runs:
       env:
         git_host: github.com
         git_username: git
+        GITHUB_TOKEN: $SMILE_CI_SERVICE_GITHUB_SSH_PRIVATE_KEY
       run: |
         eval `ssh-agent -s`
         ssh-add - <<< "${SMILE_CI_SERVICE_GITHUB_SSH_PRIVATE_KEY}"

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,7 @@ runs:
       env:
         GITHUB_TOKEN: $SMILE_CI_SERVICE_GITHUB_TOKEN
       run: |
+        ssh-add - <<< "${SMILE_CI_SERVICE_GITHUB_SSH_PRIVATE_KEY}"
         terraform-update-variable \
           --name "s3_bucket_base_path" \
           --value "\"${{ inputs.release_version }}\"" \
@@ -29,5 +30,4 @@ runs:
           --git-checkout-path "${{ runner.temp }}/infrastructure-live" \
           --git-user-email "infrastructure+github-ci@smile.io" \
           --git-user-name "smile-ci-service" \
-          --ssh-key-secrets-manager-arn "arn:aws:secretsmanager:us-east-1:877068819435:secret:smile-ci-service-github-ssh-private-key-osnOEZ"
         terragrunt apply --terragrunt-working-dir "${{ runner.temp }}/infrastructure-live/${{ inputs.short_environment }}/us-east-1/${{ inputs.short_environment }}/services/${{ inputs.terraform_module_name }}"  --terragrunt-iam-role "arn:aws:iam::${{ fromJson('{"dev": "307739032832", "stage": "389299793054", "prod": "964498696771"}')[inputs.short_environment] }}:role/allow-auto-deploy-from-other-accounts" -input=false -auto-approve

--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,6 @@ runs:
       env:
         git_host: github.com
         git_username: git
-        GITHUB_TOKEN: $SMILE_CI_SERVICE_GITHUB_TOKEN
       run: |
         eval `ssh-agent -s`
         ssh-add - <<< "${SMILE_CI_SERVICE_GITHUB_SSH_PRIVATE_KEY}"

--- a/action.yaml
+++ b/action.yaml
@@ -19,9 +19,17 @@ runs:
       id: perform_deployment
       shell: bash
       env:
-        GITHUB_TOKEN: $SMILE_CI_SERVICE_GITHUB_TOKEN
+        git_host: github.com
+        git_username: git
       run: |
         ssh-add - <<< "${SMILE_CI_SERVICE_GITHUB_SSH_PRIVATE_KEY}"
+        git config --global credential.helper 'cache --timeout 3600'
+        store_credentials_cmd="protocol=https
+        host=${git_host}
+        username=${git_username}
+        password=${SMILE_CI_SERVICE_GITHUB_TOKEN}
+        "
+        echo "${store_credentials_cmd}" | git credential-cache store
         terraform-update-variable \
           --name "s3_bucket_base_path" \
           --value "\"${{ inputs.release_version }}\"" \

--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,8 @@ runs:
     - name: Perform deployment
       id: perform_deployment
       shell: bash
+      env:
+        GITHUB_TOKEN: $SMILE_CI_SERVICE_GITHUB_TOKEN
       run: |
         terraform-update-variable \
           --name "s3_bucket_base_path" \
@@ -27,6 +29,5 @@ runs:
           --git-checkout-path "${{ runner.temp }}/infrastructure-live" \
           --git-user-email "infrastructure+github-ci@smile.io" \
           --git-user-name "smile-ci-service" \
-          --github-token-secrets-manager-arn "arn:aws:secretsmanager:us-east-1:877068819435:secret:smile-ci-service-github-token-mKMOOR" \
           --ssh-key-secrets-manager-arn "arn:aws:secretsmanager:us-east-1:877068819435:secret:smile-ci-service-github-ssh-private-key-osnOEZ"
         terragrunt apply --terragrunt-working-dir "${{ runner.temp }}/infrastructure-live/${{ inputs.short_environment }}/us-east-1/${{ inputs.short_environment }}/services/${{ inputs.terraform_module_name }}"  --terragrunt-iam-role "arn:aws:iam::${{ fromJson('{"dev": "307739032832", "stage": "389299793054", "prod": "964498696771"}')[inputs.short_environment] }}:role/allow-auto-deploy-from-other-accounts" -input=false -auto-approve

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,7 @@ runs:
         git_host: github.com
         git_username: git
       run: |
+        eval `ssh-agent -s`
         ssh-add - <<< "${SMILE_CI_SERVICE_GITHUB_SSH_PRIVATE_KEY}"
         git config --global credential.helper 'cache --timeout 3600'
         store_credentials_cmd="protocol=https
@@ -37,5 +38,5 @@ runs:
           --git-url "https://github.com/smile-io/infrastructure-live.git" \
           --git-checkout-path "${{ runner.temp }}/infrastructure-live" \
           --git-user-email "infrastructure+github-ci@smile.io" \
-          --git-user-name "smile-ci-service" \
+          --git-user-name "smile-ci-service"
         terragrunt apply --terragrunt-working-dir "${{ runner.temp }}/infrastructure-live/${{ inputs.short_environment }}/us-east-1/${{ inputs.short_environment }}/services/${{ inputs.terraform_module_name }}"  --terragrunt-iam-role "arn:aws:iam::${{ fromJson('{"dev": "307739032832", "stage": "389299793054", "prod": "964498696771"}')[inputs.short_environment] }}:role/allow-auto-deploy-from-other-accounts" -input=false -auto-approve

--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ runs:
       env:
         git_host: github.com
         git_username: git
-        GITHUB_TOKEN: $SMILE_CI_SERVICE_GITHUB_SSH_PRIVATE_KEY
+        GITHUB_TOKEN: $SMILE_CI_SERVICE_GITHUB_TOKEN
       run: |
         eval `ssh-agent -s`
         ssh-add - <<< "${SMILE_CI_SERVICE_GITHUB_SSH_PRIVATE_KEY}"


### PR DESCRIPTION
This PR updates the action to get github token from the runner env variable instead of collecting it from secrets manager service.

We need this update since the new runners will be collecting secrets from vault instead of AWS secrets manager
